### PR TITLE
Specification of package name to be upload

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ jobs:
 
 1. Get an Anaconda token (with read and write API access) at `anaconda.org/USERNAME/settings/access` 
 2. Add it to the Secrets of the Github repository as `ANACONDA_TOKEN`
-3. Add your package name to the variable packagename in your publish_conda.yml
+3. Add your package name to the variable packagename in your publish_conda.yml. If not defined, all packages found will be uploaded.
 
 # Acknowledgements
 Most of this code is "copied" from https://github.com/fcakyon/conda-publish-action/

--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ jobs:
       with:
         subdir: 'conda-recipe'
         anacondatoken: ${{ secrets.ANACONDA_TOKEN }}
+        packagename'<INSERT_HERE_PACKAGE_NAME>'
 ```
 
 ### Example project structure
@@ -46,6 +47,7 @@ jobs:
 
 1. Get an Anaconda token (with read and write API access) at `anaconda.org/USERNAME/settings/access` 
 2. Add it to the Secrets of the Github repository as `ANACONDA_TOKEN`
+3. Add your package name to the variable packagename in your publish_conda.yml
 
 # Acknowledgements
 Most of this code is "copied" from https://github.com/fcakyon/conda-publish-action/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,5 @@ conda build --output-folder . ${RECIPE_DIR}
 
 # upload anaconda package
 export ANACONDA_API_TOKEN=${INPUT_ANACONDATOKEN}
-if test -z "$PKG_BUILD_STRING" 
-then
-      anaconda upload --label main ./noarch/*.tar.bz2 --skip
-else
-      anaconda upload "$PKG_BUILD_STRING" 
-fi
+
+anaconda upload --label main ./noarch/${INPUT_PACKAGENAME}*.tar.bz2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,9 @@ conda build --output-folder . ${RECIPE_META_YAML}
 
 # upload anaconda package
 export ANACONDA_API_TOKEN=${INPUT_ANACONDATOKEN}
-anaconda upload --label main ./noarch/*.tar.bz2
+if test -z "$PKG_BUILD_STRING" 
+then
+      anaconda upload --label main ./noarch/*.tar.bz2 --skip
+else
+      anaconda upload "$PKG_BUILD_STRING" 
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ if [ ! -f ${RECIPE_META_YAML} ]; then
 fi
 
 # build conda package
-conda build --output-folder . ${RECIPE_META_YAML}
+conda build --output-folder . ${RECIPE_DIR}
 
 # upload anaconda package
 export ANACONDA_API_TOKEN=${INPUT_ANACONDATOKEN}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,4 +25,11 @@ conda build --output-folder . ${RECIPE_DIR}
 # upload anaconda package
 export ANACONDA_API_TOKEN=${INPUT_ANACONDATOKEN}
 
-anaconda upload --label main ./noarch/${INPUT_PACKAGENAME}*.tar.bz2
+
+if [ -z "${INPUT_PACKAGENAME}" ]
+then
+      anaconda upload --label main ./noarch/*.tar.bz2 
+else
+      anaconda upload --label main ./noarch/${INPUT_PACKAGENAME}*.tar.bz2
+fi
+


### PR DESCRIPTION
- Introduction of a new variable 'packagename' into the workflow to specify which package to upload to anaconda channel (If variable isn't defined, previous behavior is maintained):

- Fix conda recipe path (should point to the folder and not to the recipe file).